### PR TITLE
Add JSR (JavaScript Registry) Support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,7 @@
 {
+  "name": "@bluerabbit/wezterminator",
+  "version": "0.0.1",
+  "exports": "./src/cli.ts",
   "compilerOptions": {
     "strict": true,
     "noImplicitAny": true,
@@ -27,6 +30,10 @@
   },
   "test": {
     "include": ["src/**/*_test.ts"]
+  },
+  "publish": {
+    "include": ["src/**/*.ts", "README.md", "LICENSE"],
+    "exclude": ["src/**/*_test.ts"]
   },
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -2,11 +2,14 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@*": "1.0.13",
+    "jsr:@std/assert@^1.0.13": "1.0.13",
     "jsr:@std/fs@*": "1.0.18",
+    "jsr:@std/fs@^1.0.18": "1.0.18",
     "jsr:@std/internal@^1.0.6": "1.0.8",
     "jsr:@std/path@*": "1.1.0",
     "jsr:@std/path@^1.1.0": "1.1.0",
-    "jsr:@std/yaml@*": "1.0.8"
+    "jsr:@std/yaml@*": "1.0.8",
+    "jsr:@std/yaml@^1.0.8": "1.0.8"
   },
   "jsr": {
     "@std/assert@1.0.13": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env
 
-import * as path from "jsr:@std/path";
-import { ensureDir } from "jsr:@std/fs";
+import * as path from "jsr:@std/path@^1.1.0";
+import { ensureDir } from "jsr:@std/fs@^1.0.18";
 import { Debug } from "./debug.ts";
 import { ConfigError, Configuration, WorkspaceContent, YamlConfig } from "./configuration.ts";
 import { WeztermCLI } from "./wezterm_cli.ts";

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,5 @@
-import * as yaml from "jsr:@std/yaml";
-import * as path from "jsr:@std/path";
+import * as yaml from "jsr:@std/yaml@^1.0.8";
+import * as path from "jsr:@std/path@^1.1.0";
 
 export class ConfigError extends Error {
   constructor(message: string) {

--- a/src/debug_test.ts
+++ b/src/debug_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "jsr:@std/assert@^1.0.13";
 import { Debug } from "./debug.ts";
 
 Deno.test("Debug.isEnabled() returns false by default", () => {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,4 +1,4 @@
-import * as path from "jsr:@std/path";
+import * as path from "jsr:@std/path@^1.1.0";
 import { WeztermCLI } from "./wezterm_cli.ts";
 import { PaneManager } from "./pane_manager.ts";
 import { Debug } from "./debug.ts";


### PR DESCRIPTION
## Summary
Prepare Wezterminator for publication to JSR (JavaScript Registry).

## Changes

### 1. Add Package Metadata
Added the following configuration to `deno.json`:
- `name`: `@bluerabbit/wezterminator` - Package name on JSR
- `version`: `0.0.1` - Initial release version
- `exports`: `./src/cli.ts` - Package entry point
- `publish`: Configuration for files to publish (source code, README, LICENSE)

### 2. Pin Dependency Versions
Added version constraints to all `jsr:@std/` modules as required by JSR:
- `jsr:@std/path` → `jsr:@std/path@^1.1.0`
- `jsr:@std/fs` → `jsr:@std/fs@^1.0.18`
- `jsr:@std/yaml` → `jsr:@std/yaml@^1.0.8`
- `jsr:@std/assert` → `jsr:@std/assert@^1.0.13`

## Usage After Publication
Once published to JSR, users can install with:
```bash
deno add @bluerabbit/wezterminator
```

## Testing
- ✅ `deno task check` - Type checking passed
- ✅ `deno fmt --check` - Formatting check passed
- ✅ `deno task lint` - Linting passed
- ✅ `deno publish --dry-run` - Pre-publish validation passed (only uncommitted changes warning)